### PR TITLE
removed watch task in Grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -144,7 +144,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-karma');
 
   grunt.registerTask('default', ['build']);
-  grunt.registerTask('build', ['test', 'concat', 'uglify', 'watch']);
+  grunt.registerTask('build', ['test', 'concat', 'uglify']);
   grunt.registerTask('test', ['jshint', 'karma:run']);
   grunt.registerTask('prepublish', ['concat', 'uglify']);
 }


### PR DESCRIPTION
This PR will remove the `watch` task from Grunt. This is because the `watch` task never completes and is waiting for any changes to the source files to run `jshint`. Talk with esri-leaflet team to see if this is necessary.
